### PR TITLE
Add custom message parameter to Telnyx Inference action

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,10 @@ jobs:
         with:
           telnyx_api_key: ${{ secrets.TELNYX_API_KEY }}
           model_name: 'meta-llama/Meta-Llama-3.1-8B-Instruct'
+          custom_message: 'Optional: Your custom review prompt here'
 ```
-The model name is optional.
+The `model_name` and `custom_message` are optional.
 
-And done , The next time a PR is open it will be automatically reviewed by Telnyx Inference.
+If you don't provide a `custom_message`, the action will use a default review prompt.
+
+And done! The next time a PR is opened, it will be automatically reviewed by Telnyx Inference.

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,9 @@ inputs:
   model_name:
     description: 'Model Name'
     default: 'meta-llama/Meta-Llama-3.1-8B-Instruct'
+  custom_message:
+    description: 'Custom message for the AI review prompt'
+    required: false
 runs:
   using: 'composite'
   steps:
@@ -28,11 +31,18 @@ runs:
         # Get the diff of the current branch against the base branch
         pr_diff=$(gh pr diff ${{ github.event.number }} --patch | grep -vE "^$" | jq -Rsa . | sed -E 's/(^.)|(.$)//g')
 
+        # Use custom message if provided, otherwise use the default message
+        if [ -n "$CUSTOM_MESSAGE" ]; then
+          review_message=$(echo "$CUSTOM_MESSAGE" | grep -vE "^$" | jq -Rsa . | sed -E 's/(^.)|(.$)//g')
+        else
+          review_message="Review this PR for me, be descriptive but straightforward, tell me what it does, a brief summary of the changes and if there are any reasons to reject this PR:"
+        fi
+
         echo "Building payload"
         json_payload=$(cat <<EOF
         {
           "model": "$MODEL_NAME",
-          "messages": [{"role": "user", "content": "Review this PR for me, be descriptive but straightforward, tell me what it does, a brief summary of the changes and if there are any reasons to reject this PR: \n$pr_diff"}]
+          "messages": [{"role": "user", "content": "$review_message\n$pr_diff"}]
         }
         EOF
         )
@@ -60,6 +70,7 @@ runs:
       env:
         TELNYX_API_KEY: ${{ inputs.telnyx_api_key }}
         MODEL_NAME: ${{ inputs.model_name }}
+        CUSTOM_MESSAGE: ${{ inputs.custom_message }}
         GITHUB_SHA: ${{ github.sha }}
         GITHUB_REPOSITORY: ${{ github.repository }}
         GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
This pull request adds a new `custom_message` parameter to the Telnyx Inference GitHub action. The `custom_message` parameter allows users to provide a custom review prompt for the AI review. If a `custom_message` is not provided, the action will use a default review prompt. This enhancement provides more flexibility and customization options for users when using the Telnyx Inference action.